### PR TITLE
Add ShopId to Package retrieval to ensure saving settings to correct …

### DIFF
--- a/client/templates/stripe.js
+++ b/client/templates/stripe.js
@@ -1,7 +1,8 @@
 Template.stripeSettings.helpers({
   packageData: function () {
     return ReactionCore.Collections.Packages.findOne({
-      name: "reaction-stripe"
+      name: "reaction-stripe",
+      shopId: ReactionCore.getShopId()
     });
   }
 });
@@ -9,7 +10,8 @@ Template.stripeSettings.helpers({
 Template.stripe.helpers({
   packageData: function () {
     return ReactionCore.Collections.Packages.findOne({
-      name: "reaction-stripe"
+      name: "reaction-stripe",
+      shopId: ReactionCore.getShopId()
     });
   }
 });


### PR DESCRIPTION
…package

This fixes for multi tenancy issue where Stripe data was saving to first package it found, rather than the shop it belongs to.  