### PR TITLE
Add Luhn algorithm check for better validation

### DIFF
--- a/common/collections.js
+++ b/common/collections.js
@@ -24,7 +24,7 @@ ReactionCore.Schemas.StripePayment = new SimpleSchema({
   },
   cardNumber: {
     type: String,
-    min: 14,
+    min: 13,
     max: 16,
     label: "Card number"
   },

--- a/server/stripe.js
+++ b/server/stripe.js
@@ -1,8 +1,16 @@
 /* eslint camelcase: 0 */
 
+const LuhnValid = function (x) {
+  return [...x].reverse().reduce((sum, c, i) => {
+    let d = parseInt(c, 10);
+    if (i % 2 !== 0) { d *= 2; }
+    if (d > 9) { d -= 9; }
+    return sum + d;
+  }, 0) % 10 === 0;
+};
 
 const ValidCardNumber = Match.Where(function (x) {
-  return /^[0-9]{14,16}$/.test(x);
+  return /^[0-9]{13,16}$/.test(x) && LuhnValid(x);
 });
 
 const ValidExpireMonth = Match.Where(function (x) {


### PR DESCRIPTION
Almost all major credit/debit cards across the world, including all of those that Stripe accepts (according to https://support.stripe.com/questions/which-cards-and-payment-types-can-i-accept-with-stripe), can be validated by the Luhn algorithm. This implements a method to more robustly validate credit card numbers vs. length-only checks. This can increase UI responsiveness slightly by removing the need to check obviously-invalid card numbers via submission to the Stripe API - it's extremely rare (though not impossible) that a customer will mistype their card number and still get a Luhn-passing series of digits.

This changeset also decreases the lower card number bound from 14 to 13. Some Visa cards, particularly debit cards of long-time bank account holders (e.g. at TD Bank - see https://github.com/formvalidation/support/issues/402), still exist in 13-digit ranges.